### PR TITLE
Revert "kernel: Set full path to DTC"

### DIFF
--- a/build/tasks/kernel.mk
+++ b/build/tasks/kernel.mk
@@ -212,8 +212,6 @@ PATH_OVERRIDE += $(TOOLS_PATH_OVERRIDE)
 
 KERNEL_ADDITIONAL_CONFIG_OUT := $(KERNEL_OUT)/.additional_config
 
-KERNEL_MAKE_FLAGS += DTC=$(KERNEL_BUILD_OUT_PREFIX)$(DTC)
-
 # Internal implementation of make-kernel-target
 # $(1): output path (The value passed to O=)
 # $(2): target to build (eg. defconfig, modules, dtbo.img)


### PR DESCRIPTION
This reverts commit 5061962d73e10ee751825ee7b2a880bf4186e904.

Reason for revert: breaks build with upstreamed dtc >

Change-Id: Idcbb7b95bd54bb6ecfe30f3d55ee90bd57708995